### PR TITLE
Remove deprecated `EmberError` and `assign`

### DIFF
--- a/addon/mixins/fetch-request.js
+++ b/addon/mixins/fetch-request.js
@@ -1,5 +1,4 @@
 import { A } from '@ember/array';
-import EmberError from '@ember/error';
 import Mixin from '@ember/object/mixin';
 import { assign } from '@ember/polyfills';
 import { get } from '@ember/object';
@@ -394,7 +393,7 @@ export default Mixin.create({
    */
   get(url) {
     if (arguments.length > 1 || url.indexOf('/') !== -1) {
-      throw new EmberError(
+      throw new Error(
         'It seems you tried to use `.get` to make a request! Use the `.request` method instead.'
       );
     }

--- a/addon/mixins/fetch-request.js
+++ b/addon/mixins/fetch-request.js
@@ -1,6 +1,5 @@
 import { A } from '@ember/array';
 import Mixin from '@ember/object/mixin';
-import { assign } from '@ember/polyfills';
 import { get } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import fetch from 'fetch';
@@ -218,7 +217,7 @@ export default Mixin.create({
    * @return {object}
    */
   options(url, options = {}) {
-    options = assign({}, options);
+    options = Object.assign({}, options);
     options.url = this._buildURL(url, options);
     options.type = options.type || 'GET';
     options.dataType = options.dataType || 'json';
@@ -423,7 +422,7 @@ export default Mixin.create({
    */
   _getFullHeadersHash(headers) {
     const classHeaders = get(this, 'headers');
-    return assign({}, classHeaders, headers);
+    return Object.assign({}, classHeaders, headers);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack": "^5.90.3"
   },
   "engines": {
-    "node": "16.*"
+    "node": ">= 16.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Task:
 - Remove deprecated `EmberError` - https://deprecations.emberjs.com/id/deprecate-ember-error
 - Remove deprecated `assign` - https://deprecations.emberjs.com/id/ember-polyfills-deprecate-assign